### PR TITLE
Add core text primitives and tests

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/Cell.kt
+++ b/src/main/kotlin/terminalbuffer/model/Cell.kt
@@ -1,0 +1,10 @@
+package com.vanjasretenovic.terminalbuffer.model
+
+data class Cell(
+    val character: Char? = null,
+    val foreground: TerminalColor = TerminalColor.DEFAULT,
+    val background: TerminalColor = TerminalColor.DEFAULT,
+    val style: TextStyle = TextStyle(),
+) {
+    val isEmpty get() = character == null
+}

--- a/src/main/kotlin/terminalbuffer/model/TerminalColor.kt
+++ b/src/main/kotlin/terminalbuffer/model/TerminalColor.kt
@@ -1,0 +1,23 @@
+package com.vanjasretenovic.terminalbuffer.model
+
+enum class TerminalColor {
+    DEFAULT,
+
+    BLACK,
+    RED,
+    GREEN,
+    YELLOW,
+    BLUE,
+    MAGENTA,
+    CYAN,
+    WHITE,
+
+    BRIGHT_BLACK,
+    BRIGHT_RED,
+    BRIGHT_GREEN,
+    BRIGHT_YELLOW,
+    BRIGHT_BLUE,
+    BRIGHT_MAGENTA,
+    BRIGHT_CYAN,
+    BRIGHT_WHITE
+}

--- a/src/main/kotlin/terminalbuffer/model/TextStyle.kt
+++ b/src/main/kotlin/terminalbuffer/model/TextStyle.kt
@@ -1,0 +1,8 @@
+package com.vanjasretenovic.terminalbuffer.model
+
+data class TextStyle(
+    val bold: Boolean = false,
+    val italic: Boolean = false,
+    val underline: Boolean = false,
+    val strikethrough: Boolean = false
+)

--- a/src/test/kotlin/terminalbuffer/model/CellTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/CellTest.kt
@@ -1,0 +1,55 @@
+package terminalbuffer.model
+
+import com.vanjasretenovic.terminalbuffer.model.Cell
+import com.vanjasretenovic.terminalbuffer.model.TerminalColor
+import com.vanjasretenovic.terminalbuffer.model.TextStyle
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CellTest {
+
+    @Test
+    fun `should create empty cell with default attributes`() {
+        val cell = Cell()
+
+        assertNull(cell.character)
+        assertEquals(TerminalColor.DEFAULT, cell.foreground)
+        assertEquals(TerminalColor.DEFAULT, cell.background)
+        assertEquals(TextStyle(), cell.style)
+        assertTrue(cell.isEmpty)
+    }
+
+    @Test
+    fun `should create non-empty cell with custom attributes`() {
+        val style = TextStyle(
+            bold = true,
+            italic = true,
+            underline = false
+        )
+
+        val cell = Cell(
+            character = 'A',
+            foreground = TerminalColor.GREEN,
+            background = TerminalColor.BLACK,
+            style = style
+        )
+
+        assertEquals('A', cell.character)
+        assertEquals(TerminalColor.GREEN, cell.foreground)
+        assertEquals(TerminalColor.BLACK, cell.background)
+        assertEquals(style, cell.style)
+        assertFalse(cell.isEmpty)
+    }
+
+    @Test
+    fun `should treat space as non-empty character`() {
+        val cell = Cell(character = ' ')
+
+        assertEquals(' ', cell.character)
+        assertFalse(cell.isEmpty)
+    }
+}

--- a/src/test/kotlin/terminalbuffer/model/TextStyleTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/TextStyleTest.kt
@@ -1,0 +1,32 @@
+package terminalbuffer.model
+
+import com.vanjasretenovic.terminalbuffer.model.TextStyle
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TextStyleTest {
+
+    @Test
+    fun `should create default text style with all flags disabled`() {
+        val style = TextStyle()
+
+        assertFalse(style.bold)
+        assertFalse(style.italic)
+        assertFalse(style.underline)
+    }
+
+    @Test
+    fun `should create text style with selected flags enabled`() {
+        val style = TextStyle(
+            bold = true,
+            italic = false,
+            underline = true
+        )
+
+        assertTrue(style.bold)
+        assertFalse(style.italic)
+        assertTrue(style.underline)
+    }
+}


### PR DESCRIPTION
## Description

Implements the fundamental text primitives required for the terminal buffer.

This PR introduces the basic data structures used to represent terminal content:
- terminal colors
- text style attributes
- terminal cell model

These primitives serve as the foundation for further components such as `Row`, `Screen`, and the main `TerminalBuffer`.

## Related Issue

Closes #1 

## Changes

- Added `TerminalColor` enum representing default and standard terminal colors
- Added `TextStyle` model supporting bold, italic, and underline flags
- Added `Cell` model representing a single terminal character cell
- Implemented `isEmpty` derived property for detecting empty cells
- Added unit tests for `TextStyle` and `Cell`

## Acceptance Criteria

- [x] Feature or component implemented according to the task requirements
- [x] Code compiles successfully
- [x] Unit tests added or updated
- [x] Existing tests pass
- [x] Edge cases considered

## Tests

Added unit tests covering:
- default `TextStyle` initialization
- custom `TextStyle` flags
- default empty `Cell` state
- `Cell` with custom attributes
- distinction between empty cell (`null`) and space character (`' '`)

## Notes

An empty cell is represented using `character = null`.