### PR TITLE
Defined Scrollback model and tests

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/Screen.kt
+++ b/src/main/kotlin/terminalbuffer/model/Screen.kt
@@ -17,7 +17,7 @@ class Screen(
 
     operator fun get(row: Int): Row {
         validateRowIndex(row)
-        return rows[row]
+        return rows.elementAt(row)
     }
 
     fun scroll(): Row{

--- a/src/main/kotlin/terminalbuffer/model/Scrollback.kt
+++ b/src/main/kotlin/terminalbuffer/model/Scrollback.kt
@@ -1,0 +1,27 @@
+package com.vanjasretenovic.terminalbuffer.model
+
+class Scrollback(val maxSize: Int) {
+    init {
+        require(maxSize > 0) { "Scrollback size must be greater than 0" }
+    }
+
+    private val rows: ArrayDeque<Row> = ArrayDeque()
+
+    private fun validateRowIndex(row: Int) {
+        require(row in 0 until rows.size) { "Scrollback row index $row out of $maxSize rows" }
+    }
+
+    operator fun get(row: Int): Row {
+        validateRowIndex(row)
+        return rows.elementAt(row)
+    }
+
+    fun add(row: Row) {
+        if(rows.size == maxSize) { rows.removeFirst(); }
+        rows.addLast(row)
+    }
+
+    fun size() = rows.size
+
+    fun clear() { rows.clear(); }
+}

--- a/src/test/kotlin/terminalbuffer/model/ScrollbackTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/ScrollbackTest.kt
@@ -1,0 +1,74 @@
+package terminalbuffer.model
+
+import com.vanjasretenovic.terminalbuffer.model.Row
+import com.vanjasretenovic.terminalbuffer.model.Scrollback
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class ScrollbackTest {
+
+    @Test
+    fun `should initialize empty scrollback`() {
+        val scrollback = Scrollback(3)
+
+        assertEquals(0, scrollback.size())
+    }
+
+    @Test
+    fun `should throw when max size is invalid`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Scrollback(0)
+        }
+    }
+
+    @Test
+    fun `should add rows to scrollback`() {
+        val scrollback = Scrollback(3)
+
+        val row = Row(5)
+
+        scrollback.add(row)
+
+        assertEquals(1, scrollback.size())
+        assertEquals(row, scrollback[0])
+    }
+
+    @Test
+    fun `should discard oldest row when capacity exceeded`() {
+        val scrollback = Scrollback(2)
+
+        val row1 = Row(5)
+        val row2 = Row(5)
+        val row3 = Row(5)
+
+        scrollback.add(row1)
+        scrollback.add(row2)
+        scrollback.add(row3)
+
+        assertEquals(2, scrollback.size())
+        assertEquals(row2, scrollback[0])
+        assertEquals(row3, scrollback[1])
+    }
+
+    @Test
+    fun `should throw when accessing invalid index`() {
+        val scrollback = Scrollback(3)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            scrollback[0]
+        }
+    }
+
+    @Test
+    fun `should clear scrollback`() {
+        val scrollback = Scrollback(3)
+
+        scrollback.add(Row(5))
+        scrollback.add(Row(5))
+
+        scrollback.clear()
+
+        assertEquals(0, scrollback.size())
+    }
+}


### PR DESCRIPTION
## Description

Implements the `Scrollback` container responsible for storing rows that scroll off the visible screen.

The scrollback maintains a bounded history of `Row` objects and automatically discards the oldest entries when the configured capacity is exceeded.

## Related Issue

Closes #7 

## Changes

- Added `Scrollback` class for terminal history storage
- Implemented internal storage using `ArrayDeque<Row>`
- Added configurable maximum history size
- Implemented automatic removal of the oldest row when capacity is exceeded
- Added indexed access to stored rows
- Implemented `clear()` method
- Added validation for maximum size and index bounds
- Added unit tests covering initialization, insertion, capacity behavior, and clearing

## Acceptance Criteria

- [x] Feature implemented according to task requirements
- [x] Code compiles successfully
- [x] Unit tests added
- [x] All tests pass
- [x] Edge cases considered

## Tests

Added unit tests verifying:
- scrollback initialization
- adding rows to history
- enforcing maximum capacity
- correct removal of oldest rows
- index bounds validation
- clearing scrollback contents

## Notes

`ArrayDeque` is used to efficiently support history operations (`removeFirst` + `addLast`) with O(1) complexity.