### PR TITLE
Added CursorPosition model and implemented tests including TerminalBuffer

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/CursorPosition.kt
+++ b/src/main/kotlin/terminalbuffer/model/CursorPosition.kt
@@ -1,0 +1,6 @@
+package com.vanjasretenovic.terminalbuffer.model
+
+data class CursorPosition(
+    val row: Int,
+    val column: Int
+)

--- a/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
+++ b/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
@@ -5,13 +5,18 @@ class TerminalBuffer(
     val height: Int,
     val historySize: Int
 ) {
+    val screen: Screen
+    val scrollback: Scrollback
+    var cursor: CursorPosition = CursorPosition(0, 0)
+        private set
+
     init {
         require(width > 0 && height > 0) { "Invalid terminal screen size: $width x $height" }
         require(historySize > 0) { "Invalid history size: $historySize, must be greater than zero" }
-    }
 
-    val screen = Screen(width, height)
-    val scrollback = Scrollback(historySize)
+        screen = Screen(width, height)
+        scrollback = Scrollback(historySize)
+    }
 
     operator fun get(row: Int): Row {
         require(row in 0 until height) { "Terminal row index $row out of $height" }
@@ -23,4 +28,14 @@ class TerminalBuffer(
     private fun setCellAt(row: Int, column: Int, cell: Cell) { screen[row][column] = cell }
 
     private fun createCell(character: Char?) = Cell(character)
+
+    private fun validateCursorPosition(cursorPosition: CursorPosition) {
+        require(cursorPosition.row in 0 until height) { "Invalid cursor position: ${cursorPosition.row}, ${cursorPosition.column}" }
+        require(cursorPosition.column in 0 until width) { "Invalid cursor position: ${cursorPosition.row}, ${cursorPosition.column}" }
+    }
+
+    fun setCursor(cursorPosition: CursorPosition) {
+        validateCursorPosition(cursorPosition)
+        cursor = cursorPosition
+    }
 }

--- a/src/test/kotlin/terminalbuffer/model/CursorPositionTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/CursorPositionTest.kt
@@ -1,0 +1,17 @@
+package terminalbuffer.model
+
+import com.vanjasretenovic.terminalbuffer.model.CursorPosition
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CursorPositionTest {
+
+    @Test
+    fun `should create cursor position`() {
+        val cursor = CursorPosition(row = 2, column = 4)
+
+        assertEquals(2, cursor.row)
+        assertEquals(4, cursor.column)
+    }
+}

--- a/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
@@ -1,5 +1,6 @@
 package terminalbuffer.model
 
+import com.vanjasretenovic.terminalbuffer.model.CursorPosition
 import com.vanjasretenovic.terminalbuffer.model.Row
 import com.vanjasretenovic.terminalbuffer.model.TerminalBuffer
 
@@ -61,6 +62,50 @@ class TerminalBufferTest {
 
         assertThrows(IllegalArgumentException::class.java) {
             buffer[3]
+        }
+    }
+
+    @Test
+    fun `should initialize cursor at top left position`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        assertEquals(0, buffer.cursor.row)
+        assertEquals(0, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should set cursor within screen bounds`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.setCursor(CursorPosition(row = 2, column = 4))
+
+        assertEquals(2, buffer.cursor.row)
+        assertEquals(4, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should throw when setting cursor outside screen row bounds`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.setCursor(CursorPosition(row = -1, column = 0))
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.setCursor(CursorPosition(row = 3, column = 0))
+        }
+    }
+
+    @Test
+    fun `should throw when setting cursor outside screen column bounds`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.setCursor(CursorPosition(row = 0, column = -1))
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.setCursor(CursorPosition(row = 0, column = 5))
         }
     }
 }


### PR DESCRIPTION
## Description

Introduces cursor state management for the terminal buffer.

This PR adds a `CursorPosition` model and integrates cursor state into `TerminalBuffer`. The cursor is initialized at the top-left corner of the screen `(0,0)` and can be explicitly updated through a controlled setter that validates screen bounds.

This establishes the foundation required for future cursor movement and text editing operations.

## Related Issue

Closes #11 

## Changes

- Added `CursorPosition` data model
- Added cursor state to `TerminalBuffer`
- Initialized cursor at `(0, 0)`
- Implemented controlled cursor update via `setCursor`
- Added validation to prevent cursor from leaving screen bounds
- Added unit tests for cursor initialization and assignment

## Acceptance Criteria

- [x] CursorPosition model implemented
- [x] TerminalBuffer stores cursor state
- [x] Cursor initialized at `(0,0)`
- [x] Cursor can be explicitly set within screen bounds
- [x] Invalid cursor assignments throw exceptions
- [x] Unit tests added and passing

## Tests

Added tests verifying:
- cursor default initialization
- valid cursor assignment
- invalid row bounds
- invalid column bounds

## Notes

The cursor setter is restricted using `private set` to ensure cursor state can only be modified through validated buffer operations.