### PR TITLE
Added insert text operation and comprehensive tests

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
+++ b/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
@@ -27,6 +27,10 @@ class TerminalBuffer(
 
     private fun setCellAt(row: Int, column: Int, cell: Cell) { screen[row][column] = cell }
 
+    private fun getCurrentCell() = getCellAt(cursor.row, cursor.column)
+
+    private fun setCurrentCell(cell: Cell) { setCellAt(cursor.row, cursor.column, cell) }
+
     private fun createCell(character: Char?) = Cell(character)
 
     private fun validateCursorPosition(cursorPosition: CursorPosition) {
@@ -62,7 +66,7 @@ class TerminalBuffer(
     fun moveCursorOnStartLine() { cursor = cursor.copy(column = 0) }
 
     fun writeChar(char: Char) {
-        setCellAt(cursor.row, cursor.column, createCell(char))
+        setCurrentCell(createCell(char))
 
         if (cursor.column == width - 1) newLine()
         else moveCursorRight()
@@ -81,5 +85,19 @@ class TerminalBuffer(
 
     fun writeText(text: String) {
         for (char in text) writeChar(char)
+    }
+
+    fun insertText(text: String) {
+        var index = 0
+        var tmpText: String = text
+        var savedCursor = CursorPosition(0, 0)
+
+        while (index < tmpText.length) {
+            if(!getCurrentCell().isEmpty) tmpText += getCurrentCell().character
+            writeChar(tmpText[index++])
+            if(index == text.length) savedCursor = cursor.copy()
+        }
+
+        cursor = savedCursor.copy()
     }
 }

--- a/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
@@ -277,4 +277,134 @@ class TerminalBufferTest {
         assertEquals("PQRST", buffer[0].asString())
         assertEquals("U    ", buffer[1].asString())
     }
+
+    @Test
+    fun `should insert text into empty line`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.insertText("ABC")
+
+        assertEquals("ABC  ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+        assertEquals("     ", buffer[2].asString())
+
+        assertEquals(0, buffer.cursor.row)
+        assertEquals(3, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should insert text in the middle of existing line`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABDE")
+        buffer.setCursor(CursorPosition(0, 2))
+
+        buffer.insertText("C")
+
+        assertEquals("ABCDE", buffer[0].asString())
+        assertEquals(0, buffer.cursor.row)
+        assertEquals(3, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should shift characters right when inserting text`() {
+        val buffer = TerminalBuffer(width = 6, height = 3, historySize = 10)
+
+        buffer.writeText("ABEF")
+        buffer.setCursor(CursorPosition(0, 2))
+
+        buffer.insertText("CD")
+
+        assertEquals("ABCDEF", buffer[0].asString())
+        assertEquals(0, buffer.cursor.row)
+        assertEquals(4, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should wrap overflow to next line when inserting`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDE")
+        buffer.setCursor(CursorPosition(0, 2))
+
+        buffer.insertText("XY")
+
+        assertEquals("ABXYC", buffer[0].asString())
+        assertEquals("DE   ", buffer[1].asString())
+        assertEquals(0, buffer.cursor.row)
+        assertEquals(4, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should cascade inserted text across multiple lines`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDEFGHIJ")
+        buffer.setCursor(CursorPosition(0, 2))
+
+        buffer.insertText("XY")
+
+        assertEquals("ABXYC", buffer[0].asString())
+        assertEquals("DEFGH", buffer[1].asString())
+        assertEquals("IJ   ", buffer[2].asString())
+    }
+
+    @Test
+    fun `should insert after prior write-triggered scroll state`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.writeText("ABCDEFGHIJ")
+        buffer.setCursor(CursorPosition(0, 2))
+
+        buffer.insertText("XY")
+
+        assertEquals(1, buffer.scrollback.size())
+        assertEquals("ABCDE", buffer.scrollback[0].asString())
+        assertEquals("FGXYH", buffer[0].asString())
+        assertEquals("IJ   ", buffer[1].asString())
+    }
+
+    @Test
+    fun `should respect scrollback max size during insert scrolling`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 1)
+
+        buffer.writeText("ABCDEFGHIJ")
+        buffer.setCursor(CursorPosition(0, 2))
+
+        buffer.insertText("XYZ")
+
+        assertEquals(1, buffer.scrollback.size())
+        assertEquals("ABCDE", buffer.scrollback[0].asString())
+        assertEquals("FGXYZ", buffer[0].asString())
+        assertEquals("HIJ  ", buffer[1].asString())
+    }
+
+    @Test
+    fun `should insert text at end of line`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCD")
+        buffer.setCursor(CursorPosition(0, 4))
+
+        buffer.insertText("E")
+
+        assertEquals("ABCDE", buffer[0].asString())
+        assertEquals(1, buffer.cursor.row)
+        assertEquals(0, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should insert into current screen content after prior scroll`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.writeText("ABCDEFGHIJ")
+        buffer.setCursor(CursorPosition(0, 0))
+
+        buffer.insertText("Z")
+
+        assertEquals(1, buffer.scrollback.size())
+        assertEquals("ABCDE", buffer.scrollback[0].asString())
+        assertEquals("ZFGHI", buffer[0].asString())
+        assertEquals("J    ", buffer[1].asString())
+    }
 }


### PR DESCRIPTION
## Description

Implements text insertion functionality in `TerminalBuffer`.

Unlike the existing write operation which overwrites characters, insertion shifts existing characters to the right to make space for the new text. Overflowing characters cascade to subsequent positions and may propagate across multiple lines. If cascading reaches the bottom of the screen, scrolling occurs and removed rows are stored in the scrollback buffer.

Cursor position is preserved after the inserted text, ensuring correct terminal editing behavior.

## Related Issue

Closes #17 

## Changes

- Implemented `insertText` operation in `TerminalBuffer`
- Added cascading shift behavior for existing characters
- Implemented line wrapping during insertion
- Integrated screen scrolling when cascading reaches screen bottom
- Preserved cursor position after insertion
- Added unit tests covering insertion, cascading, wrapping, and scrolling behavior

## Acceptance Criteria

- [x] Text can be inserted at the current cursor position
- [x] Existing characters shift right to make space
- [x] Overflow wraps to the next line
- [x] Cascading insertion across multiple lines works correctly
- [x] Screen scrolling occurs when insertion reaches the bottom
- [x] Scrollback stores scrolled rows
- [x] Cursor position is restored after insertion
- [x] Unit tests added and passing

## Tests

Added tests verifying:
- insertion into empty lines
- insertion within existing text
- shifting characters within a row
- cascading insertion across multiple rows
- insertion causing screen scroll
- scrollback capacity behavior