### PR TITLE
Added fill line operation and tests

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
+++ b/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
@@ -18,8 +18,12 @@ class TerminalBuffer(
         scrollback = Scrollback(historySize)
     }
 
-    operator fun get(row: Int): Row {
+    private fun validateRowIndex(row: Int) {
         require(row in 0 until height) { "Terminal row index $row out of $height" }
+    }
+
+    operator fun get(row: Int): Row {
+        validateRowIndex(row)
         return screen[row]
     }
 
@@ -99,5 +103,10 @@ class TerminalBuffer(
         }
 
         cursor = savedCursor.copy()
+    }
+
+    fun fillLine(index: Int, char: Char? = null) {
+        validateRowIndex(index)
+        for (col in 0 until width) setCellAt(index, col, createCell(char))
     }
 }

--- a/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
@@ -407,4 +407,43 @@ class TerminalBufferTest {
         assertEquals("ZFGHI", buffer[0].asString())
         assertEquals("J    ", buffer[1].asString())
     }
+
+    @Test
+    fun `should fill line with character`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.fillLine(1, 'X')
+
+        assertEquals("XXXXX", buffer[1].asString())
+    }
+
+    @Test
+    fun `should clear line when filling with null`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDE")
+        buffer.fillLine(0, null)
+
+        assertEquals("     ", buffer[0].asString())
+    }
+
+    @Test
+    fun `should not modify other lines when filling`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDE")
+        buffer.fillLine(1, 'X')
+
+        assertEquals("ABCDE", buffer[0].asString())
+        assertEquals("XXXXX", buffer[1].asString())
+    }
+
+    @Test
+    fun `should throw when row index is invalid`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.fillLine(3, 'X')
+        }
+    }
 }


### PR DESCRIPTION
## Description

Implements the line fill operation in `TerminalBuffer`.

This feature allows filling a specific screen row with a given character or clearing the row by filling it with empty cells. The operation updates all cells in the target row while preserving screen dimensions and leaving other rows and scrollback content unchanged.

This functionality supports terminal editing commands such as clearing or resetting a line.

## Related Issue

Closes #19 

## Changes

- Implemented `fillLine(row: Int, char: Char?)` method in `TerminalBuffer`
- Replaces all cells in the specified row with the provided character
- Supports clearing a row by filling it with empty cells
- Added validation for row index bounds
- Added unit tests covering fill and clear behavior

## Acceptance Criteria

- [x] Line can be filled with a specified character
- [x] Passing `null` clears the line
- [x] Only the specified row is modified
- [x] Scrollback remains unchanged
- [x] Invalid row index throws an exception
- [x] Code compiles successfully
- [x] Unit tests added and passing

## Tests

Added tests verifying:
- filling a line with a character
- clearing a line using `null`
- ensuring other rows remain unchanged
- validating row index bounds