### PR TITLE
Added append empty line operation and tests

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
+++ b/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
@@ -83,7 +83,7 @@ class TerminalBuffer(
             moveCursorDown()
         }
         else {
-            scrollback.add(screen.scroll())
+            appendEmptyLine()
         }
     }
 
@@ -108,5 +108,9 @@ class TerminalBuffer(
     fun fillLine(index: Int, char: Char? = null) {
         validateRowIndex(index)
         for (col in 0 until width) setCellAt(index, col, createCell(char))
+    }
+
+    fun appendEmptyLine() {
+        scrollback.add(screen.scroll())
     }
 }

--- a/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
@@ -446,4 +446,71 @@ class TerminalBufferTest {
             buffer.fillLine(3, 'X')
         }
     }
+
+    @Test
+    fun `should append empty line at bottom of screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDE")
+        buffer.appendEmptyLine()
+
+        assertEquals("     ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+        assertEquals("     ", buffer[2].asString())
+
+        assertEquals(1, buffer.scrollback.size())
+        assertEquals("ABCDE", buffer.scrollback[0].asString())
+    }
+
+    @Test
+    fun `should preserve screen height when appending empty line`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.appendEmptyLine()
+
+        assertEquals("     ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+    }
+
+    @Test
+    fun `should append empty row at bottom after scrolling screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDE")
+        buffer.setCursor(CursorPosition(1, 0))
+        buffer.writeText("FGHIJ")
+
+        buffer.appendEmptyLine()
+
+        assertEquals("FGHIJ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+        assertEquals("     ", buffer[2].asString())
+
+        assertEquals(1, buffer.scrollback.size())
+        assertEquals("ABCDE", buffer.scrollback[0].asString())
+    }
+
+    @Test
+    fun `should not modify cursor position when appending empty line`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.setCursor(CursorPosition(1, 3))
+        buffer.appendEmptyLine()
+
+        assertEquals(1, buffer.cursor.row)
+        assertEquals(3, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should respect scrollback max size when appending empty line`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 1)
+
+        buffer.writeText("ABCDE")
+        buffer.appendEmptyLine()
+        buffer.writeText("FGHIJ")
+        buffer.appendEmptyLine()
+
+        assertEquals(1, buffer.scrollback.size())
+        assertEquals("FGHIJ", buffer.scrollback[0].asString())
+    }
 }


### PR DESCRIPTION
## Description

Implements the append empty line operation in `TerminalBuffer`.

This operation simulates terminal behavior when a new line is added at the bottom of the screen. The top row of the screen is removed and stored in the scrollback buffer, while a new empty row is appended at the bottom. The screen height remains constant and the cursor position is not affected.

## Related Issue

Closes #21 

## Changes

- Implemented `appendEmptyLine()` method in `TerminalBuffer`
- Integrated screen scrolling using `screen.scroll()`
- Stored removed rows in the scrollback buffer
- Preserved screen height after appending a new line
- Ensured cursor position remains unchanged
- Added unit tests covering append behavior and scrollback interaction

## Acceptance Criteria

- [x] Empty line can be appended at the bottom of the screen
- [x] Top screen row is moved to scrollback
- [x] Screen height remains constant
- [x] Scrollback respects configured maximum size
- [x] Cursor position remains unchanged
- [x] Code compiles successfully
- [x] Unit tests added and passing

## Tests

Added tests verifying:
- appending an empty line on a partially filled screen
- ensuring the top row moves to scrollback
- verifying a new empty row appears at the bottom
- preserving cursor position
- respecting scrollback maximum size