### PR TITLE
Implemented clear visible screen operation and tests

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
+++ b/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
@@ -113,4 +113,9 @@ class TerminalBuffer(
     fun appendEmptyLine() {
         scrollback.add(screen.scroll())
     }
+
+    fun clearScreen() {
+        screen.clear()
+        setCursor(CursorPosition(0, 0))
+    }
 }

--- a/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
@@ -513,4 +513,67 @@ class TerminalBufferTest {
         assertEquals(1, buffer.scrollback.size())
         assertEquals("FGHIJ", buffer.scrollback[0].asString())
     }
+
+    @Test
+    fun `should clear all screen rows`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDEFG")
+        buffer.clearScreen()
+
+        assertEquals("     ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+        assertEquals("     ", buffer[2].asString())
+    }
+
+    @Test
+    fun `should preserve scrollback when clearing screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.writeText("ABCDEFGHIJ")
+        buffer.clearScreen()
+
+        assertEquals(1, buffer.scrollback.size())
+        assertEquals("ABCDE", buffer.scrollback[0].asString())
+        assertEquals("     ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+    }
+
+    @Test
+    fun `should reset cursor when clearing screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABC")
+        buffer.setCursor(CursorPosition(1, 3))
+
+        buffer.clearScreen()
+
+        assertEquals(0, buffer.cursor.row)
+        assertEquals(0, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should preserve screen dimensions when clearing screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDEFG")
+        buffer.clearScreen()
+
+        assertEquals(5, buffer[0].width)
+        assertEquals(5, buffer[1].width)
+        assertEquals(5, buffer[2].width)
+    }
+
+    @Test
+    fun `should clear already empty screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.clearScreen()
+
+        assertEquals("     ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+        assertEquals("     ", buffer[2].asString())
+        assertEquals(0, buffer.cursor.row)
+        assertEquals(0, buffer.cursor.column)
+    }
 }


### PR DESCRIPTION
## Description

Implements the screen clear operation in `TerminalBuffer`.

This operation resets the visible screen by replacing all rows with empty cells while preserving the screen dimensions. The scrollback buffer remains unchanged, and the cursor position is reset to the top-left corner `(0, 0)`.

This behavior matches terminal commands that clear the visible screen without affecting the terminal history.

## Related Issue

Closes #23 

## Changes

- Implemented `clearScreen()` method in `TerminalBuffer`
- Reset all screen rows to empty cells
- Preserved scrollback buffer contents
- Reset cursor position to `(0, 0)`
- Added unit tests covering clearing behavior and cursor reset

## Acceptance Criteria

- [x] `clearScreen()` method implemented
- [x] Screen rows are reset to empty cells
- [x] Screen dimensions remain unchanged
- [x] Scrollback buffer remains unchanged
- [x] Cursor resets to `(0, 0)`
- [x] Code compiles successfully
- [x] Unit tests added and passing

## Tests

Added tests verifying:
- clearing a screen containing text
- ensuring all rows become empty
- preserving scrollback contents
- resetting cursor position
- maintaining screen dimensions