### PR TITLE
Implemented clear whole buffer operation and tests

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
+++ b/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
@@ -118,4 +118,10 @@ class TerminalBuffer(
         screen.clear()
         setCursor(CursorPosition(0, 0))
     }
+
+    fun clearAll() {
+        screen.clear()
+        scrollback.clear()
+        setCursor(CursorPosition(0, 0))
+    }
 }

--- a/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
@@ -7,6 +7,7 @@ import com.vanjasretenovic.terminalbuffer.model.TerminalBuffer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class TerminalBufferTest {
@@ -573,6 +574,68 @@ class TerminalBufferTest {
         assertEquals("     ", buffer[0].asString())
         assertEquals("     ", buffer[1].asString())
         assertEquals("     ", buffer[2].asString())
+        assertEquals(0, buffer.cursor.row)
+        assertEquals(0, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should clear screen and scrollback`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.writeText("ABCDEFGHIJ")
+        buffer.clearAll()
+
+        assertEquals(0, buffer.scrollback.size())
+        assertEquals("     ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+    }
+
+    @Test
+    fun `should reset cursor when clearing entire buffer`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDE")
+        buffer.setCursor(CursorPosition(2, 3))
+
+        buffer.clearAll()
+
+        assertEquals(0, buffer.cursor.row)
+        assertEquals(0, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should preserve screen dimensions after clearAll`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDEFG")
+        buffer.clearAll()
+
+        assertEquals(5, buffer[0].width)
+        assertEquals(5, buffer[1].width)
+        assertEquals(5, buffer[2].width)
+    }
+
+    @Test
+    fun `should clear scrollback completely`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.writeText("ABCDEFGHIJKLMNOP")
+        assertTrue(buffer.scrollback.size() > 0)
+
+        buffer.clearAll()
+
+        assertEquals(0, buffer.scrollback.size())
+    }
+
+    @Test
+    fun `should clear already empty buffer`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.clearAll()
+
+        assertEquals(0, buffer.scrollback.size())
+        assertEquals("     ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
         assertEquals(0, buffer.cursor.row)
         assertEquals(0, buffer.cursor.column)
     }


### PR DESCRIPTION
## Description

Implements the full buffer clear operation in `TerminalBuffer`.

This operation resets the entire terminal state by clearing both the visible screen and the scrollback history. All screen rows are replaced with empty cells, the scrollback buffer is cleared, and the cursor position is reset to the top-left corner `(0, 0)`.

This behavior simulates terminal commands that completely reset the terminal buffer.

## Related Issue

Closes #25 

## Changes

- Implemented `clearAll()` method in `TerminalBuffer`
- Reset all screen rows to empty cells
- Cleared scrollback buffer
- Reset cursor position to `(0, 0)`
- Added unit tests covering full buffer clearing behavior

## Acceptance Criteria

- [x] `clearAll()` method implemented
- [x] Screen rows are reset to empty cells
- [x] Scrollback buffer is completely cleared
- [x] Screen dimensions remain unchanged
- [x] Cursor resets to `(0, 0)`
- [x] Code compiles successfully
- [x] Unit tests added and passing

## Tests

Added tests verifying:
- clearing both screen and scrollback
- resetting cursor position
- preserving screen dimensions
- clearing scrollback contents
- behavior when clearing an already empty buffer