### PR TITLE
Implemented all get content API operations and tests

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
+++ b/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
@@ -22,6 +22,14 @@ class TerminalBuffer(
         require(row in 0 until height) { "Terminal row index $row out of $height" }
     }
 
+    private fun validateColumnIndex(column: Int) {
+        require(column in 0 until width) { "Terminal column index $column out of $width" }
+    }
+
+    private fun validateScrollbackRowIndex(row: Int) {
+        require(row in 0 until scrollback.size()) { "History row index $row out of ${scrollback.size()}" }
+    }
+
     operator fun get(row: Int): Row {
         validateRowIndex(row)
         return screen[row]
@@ -123,5 +131,39 @@ class TerminalBuffer(
         screen.clear()
         scrollback.clear()
         setCursor(CursorPosition(0, 0))
+    }
+
+    private fun getRowAt(index: Int, fromHistory: Boolean = false): Row {
+        if (fromHistory) {
+            validateScrollbackRowIndex(index)
+            return scrollback[index]
+        }
+
+        validateRowIndex(index)
+        return screen[index]
+    }
+
+    fun getCharAt(row: Int, column: Int, fromHistory: Boolean = false): Char? {
+        validateColumnIndex(column)
+        return getRowAt(row, fromHistory)[column].character
+    }
+
+    fun getAttributesAt(row: Int, column: Int, fromHistory: Boolean = false): Cell {
+        validateColumnIndex(column)
+        return getRowAt(row, fromHistory)[column]
+    }
+
+    fun getLineAsString(index: Int, fromHistory: Boolean = false): String {
+        return getRowAt(index, fromHistory).asString()
+    }
+
+    fun getScreenContent(): String {
+        return (0 until height).joinToString("\n") { screen[it].asString() }
+    }
+
+    fun getFullContent(): String {
+        val history = (0 until scrollback.size()).map { scrollback[it].asString() }
+        val visible = (0 until height).map { screen[it].asString() }
+        return (history + visible).joinToString("\n")
     }
 }

--- a/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
@@ -3,6 +3,8 @@ package terminalbuffer.model
 import com.vanjasretenovic.terminalbuffer.model.CursorPosition
 import com.vanjasretenovic.terminalbuffer.model.Row
 import com.vanjasretenovic.terminalbuffer.model.TerminalBuffer
+import com.vanjasretenovic.terminalbuffer.model.TerminalColor
+import com.vanjasretenovic.terminalbuffer.model.TextStyle
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -638,5 +640,111 @@ class TerminalBufferTest {
         assertEquals("     ", buffer[1].asString())
         assertEquals(0, buffer.cursor.row)
         assertEquals(0, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should get character from screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABC")
+
+        assertEquals('A', buffer.getCharAt(0, 0))
+        assertEquals('B', buffer.getCharAt(0, 1))
+        assertEquals('C', buffer.getCharAt(0, 2))
+        assertEquals(null, buffer.getCharAt(0, 3))
+    }
+
+    @Test
+    fun `should get character from scrollback`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.writeText("ABCDEFGHIJ")
+
+        assertEquals('A', buffer.getCharAt(0, 0, fromHistory = true))
+        assertEquals('E', buffer.getCharAt(0, 4, fromHistory = true))
+    }
+
+    @Test
+    fun `should get attributes from screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("A")
+
+        val cell = buffer.getAttributesAt(0, 0)
+
+        assertEquals('A', cell.character)
+        assertEquals(TerminalColor.DEFAULT, cell.foreground)
+        assertEquals(TerminalColor.DEFAULT, cell.background)
+        assertEquals(TextStyle(), cell.style)
+    }
+
+    @Test
+    fun `should get line as string from screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABC")
+
+        assertEquals("ABC  ", buffer.getLineAsString(0))
+        assertEquals("     ", buffer.getLineAsString(1))
+    }
+
+    @Test
+    fun `should get line as string from scrollback`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.writeText("ABCDEFGHIJ")
+
+        assertEquals("ABCDE", buffer.getLineAsString(0, fromHistory = true))
+    }
+
+    @Test
+    fun `should get entire screen content as string`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        buffer.writeText("ABCDEFG")
+
+        assertEquals(
+            "ABCDE\nFG   \n     ",
+            buffer.getScreenContent()
+        )
+    }
+
+    @Test
+    fun `should get full content including scrollback and screen`() {
+        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+
+        buffer.writeText("ABCDEFGHIJ")
+
+        assertEquals(
+            "ABCDE\nFGHIJ\n     ",
+            buffer.getFullContent()
+        )
+    }
+
+    @Test
+    fun `should throw when screen row index is invalid`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.getLineAsString(3)
+        }
+    }
+
+    @Test
+    fun `should throw when scrollback row index is invalid`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.getLineAsString(0, fromHistory = true)
+        }
+    }
+
+    @Test
+    fun `should throw when column index is invalid`() {
+        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.getCharAt(0, 5)
+        }
     }
 }


### PR DESCRIPTION
## Description

Implements content access operations in `TerminalBuffer`.

This change introduces read-only APIs for retrieving terminal content from both the visible screen and the scrollback history. The methods allow accessing individual characters, cell attributes, full lines, and exporting the entire buffer content.

These operations do not modify the internal terminal state and are intended for rendering, exporting terminal output, debugging, and validating terminal state during tests.

## Related Issue

Closes #27 

## Changes

- Implemented `getCharAt()` to retrieve characters from screen or scrollback
- Implemented `getAttributesAt()` to retrieve full cell attributes from screen or scrollback
- Implemented `getLineAsString()` to return a full line as a string
- Implemented `getScreenContent()` to export the visible screen content
- Implemented `getFullContent()` to export scrollback + screen content
- Added row and column validation for content access
- Added unit tests covering character, attribute, line, and full buffer retrieval

## Acceptance Criteria

- [x] Character retrieval works for both screen and scrollback
- [x] Cell attributes can be retrieved for both screen and scrollback
- [x] Full line retrieval works for both screen and scrollback
- [x] Entire screen content can be exported as a string
- [x] Full buffer content (scrollback + screen) can be exported
- [x] Methods validate row and column bounds
- [x] Methods do not modify terminal state
- [x] Unit tests added and passing

## Tests

Added tests verifying:
- retrieving characters from screen
- retrieving characters from scrollback
- retrieving full cell attributes
- retrieving lines from screen and scrollback
- exporting entire screen content
- exporting full buffer content
- validation of row and column bounds