### PR TITLE
Implemented complete resize operation across Row, Screen, Scrollback,…

### DIFF
--- a/src/main/kotlin/terminalbuffer/model/Row.kt
+++ b/src/main/kotlin/terminalbuffer/model/Row.kt
@@ -1,11 +1,15 @@
 package com.vanjasretenovic.terminalbuffer.model
 
-class Row(val width: Int) {
+class Row(val initialWidth: Int) {
+    var width: Int
+        private set
+
     init {
-        require(width > 0) { "Width must be greater than zero" }
+        require(initialWidth > 0) { "Width must be greater than zero" }
+        width = initialWidth
     }
 
-    private val cells: MutableList<Cell> = MutableList(width) { Cell() }
+    private val cells: MutableList<Cell> = MutableList(initialWidth) { Cell() }
 
     private fun validateColumnIndex(column: Int){
         require(column in 0 until width) { "Invalid column index $column. Column index must be in range (0,${width - 1})" }
@@ -25,6 +29,15 @@ class Row(val width: Int) {
         for(i in cells.indices) {
             cells[i] = cell
         }
+    }
+
+    fun resize(newWidth: Int) {
+        require(newWidth > 0) { "New width must be greater than zero" }
+        when {
+            newWidth > width -> { repeat(newWidth - width) { cells.addLast(Cell()) } }
+            newWidth < width -> { repeat( width - newWidth) { cells.removeLast() } }
+        }
+        width = newWidth
     }
 
     fun asString() = cells.joinToString(separator = "") { it.character?.toString() ?: " " }

--- a/src/main/kotlin/terminalbuffer/model/Screen.kt
+++ b/src/main/kotlin/terminalbuffer/model/Screen.kt
@@ -1,15 +1,22 @@
 package com.vanjasretenovic.terminalbuffer.model
 
 class Screen(
-    val width: Int,
-    val height: Int
+    val initialWidth: Int,
+    val initialHeight: Int
 ) {
+    var width: Int
+        private set
+    var height: Int
+        private set
+
     init {
-        require(width > 0) { "Screen width must be greater than zero." }
-        require(height > 0) { "Screen height must be greater than zero." }
+        require(initialWidth > 0) { "Screen width must be greater than zero." }
+        require(initialHeight > 0) { "Screen height must be greater than zero." }
+        width = initialWidth
+        height = initialHeight
     }
 
-    private val rows: ArrayDeque<Row> = ArrayDeque(List(height) { Row(width) })
+    private val rows: ArrayDeque<Row> = ArrayDeque(List(initialHeight) { Row(initialWidth) })
 
     private fun validateRowIndex(row: Int) {
         require(row in 0 until height) { "Invalid row index $row. Row index must be in range (0, ${height - 1})" }
@@ -29,5 +36,23 @@ class Screen(
     fun clear() {
         rows.clear()
         repeat(height) { rows.addLast(Row(width)) }
+    }
+
+    fun resize(newWidth: Int, newHeight: Int): List<Row> {
+        require(newWidth > 0) { "New width must be greater than zero" }
+        require(newHeight > 0) { "New height must be greater than zero" }
+
+        for (i in 0 until rows.size) rows.elementAt(i).resize(newWidth)
+
+        val removed: MutableList<Row> = mutableListOf()
+        when {
+            newHeight > height -> repeat(newHeight - height) { rows.addLast(Row(newWidth)) }
+            newHeight < height -> repeat(height - newHeight) { removed.addLast(rows.removeFirst()) }
+        }
+
+        width = newWidth
+        height = newHeight
+
+        return removed
     }
 }

--- a/src/main/kotlin/terminalbuffer/model/Scrollback.kt
+++ b/src/main/kotlin/terminalbuffer/model/Scrollback.kt
@@ -24,4 +24,10 @@ class Scrollback(val maxSize: Int) {
     fun size() = rows.size
 
     fun clear() { rows.clear(); }
+
+    fun resize(newWidth: Int) {
+        require(newWidth > 0) { "New width must be greater than zero" }
+
+        for (i in 0 until rows.size) rows.elementAt(i).resize(newWidth)
+    }
 }

--- a/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
+++ b/src/main/kotlin/terminalbuffer/model/TerminalBuffer.kt
@@ -1,20 +1,26 @@
 package com.vanjasretenovic.terminalbuffer.model
 
 class TerminalBuffer(
-    val width: Int,
-    val height: Int,
+    val initialWidth: Int,
+    val initialHeight: Int,
     val historySize: Int
 ) {
     val screen: Screen
     val scrollback: Scrollback
     var cursor: CursorPosition = CursorPosition(0, 0)
         private set
+    var width: Int
+        private set
+    var height: Int
+        private set
 
     init {
-        require(width > 0 && height > 0) { "Invalid terminal screen size: $width x $height" }
+        require(initialWidth > 0 && initialHeight > 0) { "Invalid terminal screen size: $initialWidth x $initialHeight" }
         require(historySize > 0) { "Invalid history size: $historySize, must be greater than zero" }
 
-        screen = Screen(width, height)
+        width = initialWidth
+        height = initialHeight
+        screen = Screen(initialWidth, initialHeight)
         scrollback = Scrollback(historySize)
     }
 
@@ -105,7 +111,8 @@ class TerminalBuffer(
         var savedCursor = CursorPosition(0, 0)
 
         while (index < tmpText.length) {
-            if(!getCurrentCell().isEmpty) tmpText += getCurrentCell().character
+            val currentCell = getCurrentCell()
+            if (!currentCell.isEmpty) tmpText += currentCell.character!!
             writeChar(tmpText[index++])
             if(index == text.length) savedCursor = cursor.copy()
         }
@@ -165,5 +172,20 @@ class TerminalBuffer(
         val history = (0 until scrollback.size()).map { scrollback[it].asString() }
         val visible = (0 until height).map { screen[it].asString() }
         return (history + visible).joinToString("\n")
+    }
+
+    fun resize(newWidth: Int, newHeight: Int) {
+        require(newWidth > 0) { "New width must be greater than zero" }
+        require(newHeight > 0) { "New height must be greater than zero" }
+
+        val removed = screen.resize(newWidth, newHeight)
+        scrollback.resize(newWidth)
+
+        if (removed.isNotEmpty()) for(row in removed) scrollback.add(row)
+
+        width = newWidth
+        height = newHeight
+
+        setCursor(CursorPosition(cursor.row.coerceAtMost(height - 1), cursor.column.coerceAtMost(width - 1)))
     }
 }

--- a/src/test/kotlin/terminalbuffer/model/RowTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/RowTest.kt
@@ -63,4 +63,54 @@ class RowTest {
 
         assertEquals("XXXX", row.asString())
     }
+
+    @Test
+    fun `should increase row width by appending empty cells`() {
+        val row = Row(3)
+        row[0] = Cell('A')
+        row[1] = Cell('B')
+        row[2] = Cell('C')
+
+        row.resize(5)
+
+        assertEquals(5, row.width)
+        assertEquals("ABC  ", row.asString())
+    }
+
+    @Test
+    fun `should decrease row width by truncating right side`() {
+        val row = Row(5)
+        row[0] = Cell('A')
+        row[1] = Cell('B')
+        row[2] = Cell('C')
+        row[3] = Cell('D')
+        row[4] = Cell('E')
+
+        row.resize(3)
+
+        assertEquals(3, row.width)
+        assertEquals("ABC", row.asString())
+    }
+
+    @Test
+    fun `should keep row content unchanged when resizing to same width`() {
+        val row = Row(3)
+        row[0] = Cell('A')
+        row[1] = Cell('B')
+        row[2] = Cell('C')
+
+        row.resize(3)
+
+        assertEquals(3, row.width)
+        assertEquals("ABC", row.asString())
+    }
+
+    @Test
+    fun `should throw when resizing row to non positive width`() {
+        val row = Row(3)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            row.resize(0)
+        }
+    }
 }

--- a/src/test/kotlin/terminalbuffer/model/ScreenTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/ScreenTest.kt
@@ -10,7 +10,7 @@ class ScreenTest {
 
     @Test
     fun `should initialize screen with correct dimensions`() {
-        val screen = Screen(width = 5, height = 3)
+        val screen = Screen(5, 3)
 
         assertEquals(5, screen[0].width)
         assertEquals(5, screen[1].width)
@@ -73,5 +73,82 @@ class ScreenTest {
         assertEquals("     ", screen[0].asString())
         assertEquals("     ", screen[1].asString())
         assertEquals("     ", screen[2].asString())
+    }
+
+    @Test
+    fun `should increase screen width and keep existing content`() {
+        val screen = Screen(3, 2)
+        screen[0][0] = Cell('A')
+        screen[0][1] = Cell('B')
+        screen[0][2] = Cell('C')
+
+        val removedRows = screen.resize(5, 2)
+
+        assertEquals(0, removedRows.size)
+        assertEquals("ABC  ", screen[0].asString())
+        assertEquals("     ", screen[1].asString())
+    }
+
+    @Test
+    fun `should decrease screen width and truncate existing rows`() {
+        val screen = Screen(5, 2)
+        screen[0][0] = Cell('A')
+        screen[0][1] = Cell('B')
+        screen[0][2] = Cell('C')
+        screen[0][3] = Cell('D')
+        screen[0][4] = Cell('E')
+
+        val removedRows = screen.resize(3, 2)
+
+        assertEquals(0, removedRows.size)
+        assertEquals("ABC", screen[0].asString())
+        assertEquals("   ", screen[1].asString())
+    }
+
+    @Test
+    fun `should increase screen height by appending empty rows at bottom`() {
+        val screen = Screen(3, 2)
+        screen[0][0] = Cell('A')
+        screen[1][0] = Cell('B')
+
+        val removedRows = screen.resize(3, 4)
+
+        assertEquals(0, removedRows.size)
+        assertEquals("A  ", screen[0].asString())
+        assertEquals("B  ", screen[1].asString())
+        assertEquals("   ", screen[2].asString())
+        assertEquals("   ", screen[3].asString())
+    }
+
+    @Test
+    fun `should decrease screen height by removing rows from top`() {
+        val screen = Screen(3, 4)
+        screen[0][0] = Cell('A')
+        screen[1][0] = Cell('B')
+        screen[2][0] = Cell('C')
+        screen[3][0] = Cell('D')
+
+        val removedRows = screen.resize(3, 2)
+
+        assertEquals(2, removedRows.size)
+        assertEquals("A  ", removedRows[0].asString())
+        assertEquals("B  ", removedRows[1].asString())
+        assertEquals("C  ", screen[0].asString())
+        assertEquals("D  ", screen[1].asString())
+    }
+
+    @Test
+    fun `should resize width and height together`() {
+        val screen = Screen(5, 3)
+        screen[0][0] = Cell('A')
+        screen[1][0] = Cell('B')
+        screen[2][0] = Cell('C')
+
+        val removedRows = screen.resize(2, 2)
+
+        assertEquals(1, removedRows.size)
+        assertEquals("A ", removedRows[0].asString())
+        assertEquals("B ", screen[0].asString())
+        assertEquals("C ", screen[1].asString())
     }
 }

--- a/src/test/kotlin/terminalbuffer/model/ScrollbackTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/ScrollbackTest.kt
@@ -1,5 +1,6 @@
 package terminalbuffer.model
 
+import com.vanjasretenovic.terminalbuffer.model.Cell
 import com.vanjasretenovic.terminalbuffer.model.Row
 import com.vanjasretenovic.terminalbuffer.model.Scrollback
 
@@ -70,5 +71,68 @@ class ScrollbackTest {
         scrollback.clear()
 
         assertEquals(0, scrollback.size())
+    }
+
+    @Test
+    fun `should increase scrollback row widths`() {
+        val scrollback = Scrollback(10)
+
+        val row1 = Row(3)
+        row1[0] = Cell('A')
+        row1[1] = Cell('B')
+        row1[2] = Cell('C')
+
+        scrollback.add(row1)
+        scrollback.resize(5)
+
+        assertEquals("ABC  ", scrollback[0].asString())
+    }
+
+    @Test
+    fun `should decrease scrollback row widths`() {
+        val scrollback = Scrollback(10)
+
+        val row1 = Row(5)
+        row1[0] = Cell('A')
+        row1[1] = Cell('B')
+        row1[2] = Cell('C')
+        row1[3] = Cell('D')
+        row1[4] = Cell('E')
+
+        scrollback.add(row1)
+        scrollback.resize(3)
+
+        assertEquals("ABC", scrollback[0].asString())
+    }
+
+    @Test
+    fun `should resize all scrollback rows`() {
+        val scrollback = Scrollback(10)
+
+        val row1 = Row(4)
+        row1[0] = Cell('A')
+
+        val row2 = Row(4)
+        row2[0] = Cell('B')
+
+        scrollback.add(row1)
+        scrollback.add(row2)
+
+        scrollback.resize(2)
+
+        assertEquals("A ", scrollback[0].asString())
+        assertEquals("B ", scrollback[1].asString())
+    }
+
+    @Test
+    fun `should keep scrollback size unchanged when resizing width`() {
+        val scrollback = Scrollback(10)
+
+        scrollback.add(Row(4))
+        scrollback.add(Row(4))
+
+        scrollback.resize(6)
+
+        assertEquals(2, scrollback.size())
     }
 }

--- a/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
+++ b/src/test/kotlin/terminalbuffer/model/TerminalBufferTest.kt
@@ -16,7 +16,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should initialize terminal buffer with screen and scrollback`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         assertNotNull(buffer.screen)
         assertNotNull(buffer.scrollback)
@@ -27,7 +27,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should expose screen rows through buffer index operator`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         val row: Row = buffer[1]
 
@@ -37,27 +37,27 @@ class TerminalBufferTest {
     @Test
     fun `should throw when width is not positive`() {
         assertThrows(IllegalArgumentException::class.java) {
-            TerminalBuffer(width = 0, height = 3, historySize = 10)
+            TerminalBuffer(0, 3, 10)
         }
     }
 
     @Test
     fun `should throw when height is not positive`() {
         assertThrows(IllegalArgumentException::class.java) {
-            TerminalBuffer(width = 5, height = 0, historySize = 10)
+            TerminalBuffer(5, 0, 10)
         }
     }
 
     @Test
     fun `should throw when scrollback size is not positive`() {
         assertThrows(IllegalArgumentException::class.java) {
-            TerminalBuffer(width = 5, height = 3, historySize = 0)
+            TerminalBuffer(5, 3, 0)
         }
     }
 
     @Test
     fun `should throw when row index is out of bounds`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         assertThrows(IllegalArgumentException::class.java) {
             buffer[-1]
@@ -70,7 +70,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should initialize cursor at top left position`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         assertEquals(0, buffer.cursor.row)
         assertEquals(0, buffer.cursor.column)
@@ -78,7 +78,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should set cursor within screen bounds`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.setCursor(CursorPosition(row = 2, column = 4))
 
@@ -88,7 +88,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should throw when setting cursor outside screen row bounds`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         assertThrows(IllegalArgumentException::class.java) {
             buffer.setCursor(CursorPosition(row = -1, column = 0))
@@ -101,7 +101,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should throw when setting cursor outside screen column bounds`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         assertThrows(IllegalArgumentException::class.java) {
             buffer.setCursor(CursorPosition(row = 0, column = -1))
@@ -194,7 +194,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should write text within single line`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABC")
 
@@ -208,7 +208,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should wrap text to next line when reaching line end`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDE")
 
@@ -222,7 +222,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should write text across multiple lines`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDEFG")
 
@@ -236,7 +236,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should scroll screen when writing past bottom`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJK")
 
@@ -252,7 +252,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should preserve multiple scrolled rows in scrollback`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJKLMNOP")
 
@@ -269,7 +269,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should respect scrollback max size while scrolling`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 2)
+        val buffer = TerminalBuffer(5, 2, 2)
 
         buffer.writeText("ABCDEFGHIJKLMNOPQRSTU")
 
@@ -283,7 +283,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should insert text into empty line`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.insertText("ABC")
 
@@ -297,7 +297,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should insert text in the middle of existing line`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABDE")
         buffer.setCursor(CursorPosition(0, 2))
@@ -311,7 +311,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should shift characters right when inserting text`() {
-        val buffer = TerminalBuffer(width = 6, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(6, 3, 10)
 
         buffer.writeText("ABEF")
         buffer.setCursor(CursorPosition(0, 2))
@@ -325,7 +325,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should wrap overflow to next line when inserting`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDE")
         buffer.setCursor(CursorPosition(0, 2))
@@ -340,7 +340,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should cascade inserted text across multiple lines`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDEFGHIJ")
         buffer.setCursor(CursorPosition(0, 2))
@@ -354,7 +354,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should insert after prior write-triggered scroll state`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJ")
         buffer.setCursor(CursorPosition(0, 2))
@@ -369,7 +369,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should respect scrollback max size during insert scrolling`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 1)
+        val buffer = TerminalBuffer(5, 2, 1)
 
         buffer.writeText("ABCDEFGHIJ")
         buffer.setCursor(CursorPosition(0, 2))
@@ -384,7 +384,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should insert text at end of line`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCD")
         buffer.setCursor(CursorPosition(0, 4))
@@ -398,7 +398,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should insert into current screen content after prior scroll`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJ")
         buffer.setCursor(CursorPosition(0, 0))
@@ -413,7 +413,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should fill line with character`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.fillLine(1, 'X')
 
@@ -422,7 +422,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should clear line when filling with null`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDE")
         buffer.fillLine(0, null)
@@ -432,7 +432,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should not modify other lines when filling`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDE")
         buffer.fillLine(1, 'X')
@@ -443,7 +443,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should throw when row index is invalid`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         assertThrows(IllegalArgumentException::class.java) {
             buffer.fillLine(3, 'X')
@@ -452,7 +452,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should append empty line at bottom of screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDE")
         buffer.appendEmptyLine()
@@ -467,7 +467,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should preserve screen height when appending empty line`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.appendEmptyLine()
 
@@ -477,7 +477,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should append empty row at bottom after scrolling screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDE")
         buffer.setCursor(CursorPosition(1, 0))
@@ -495,7 +495,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should not modify cursor position when appending empty line`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.setCursor(CursorPosition(1, 3))
         buffer.appendEmptyLine()
@@ -506,7 +506,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should respect scrollback max size when appending empty line`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 1)
+        val buffer = TerminalBuffer(5, 2, 1)
 
         buffer.writeText("ABCDE")
         buffer.appendEmptyLine()
@@ -519,7 +519,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should clear all screen rows`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDEFG")
         buffer.clearScreen()
@@ -531,7 +531,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should preserve scrollback when clearing screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJ")
         buffer.clearScreen()
@@ -544,7 +544,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should reset cursor when clearing screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABC")
         buffer.setCursor(CursorPosition(1, 3))
@@ -557,7 +557,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should preserve screen dimensions when clearing screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDEFG")
         buffer.clearScreen()
@@ -569,7 +569,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should clear already empty screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.clearScreen()
 
@@ -582,7 +582,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should clear screen and scrollback`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJ")
         buffer.clearAll()
@@ -594,7 +594,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should reset cursor when clearing entire buffer`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDE")
         buffer.setCursor(CursorPosition(2, 3))
@@ -607,7 +607,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should preserve screen dimensions after clearAll`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDEFG")
         buffer.clearAll()
@@ -619,7 +619,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should clear scrollback completely`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJKLMNOP")
         assertTrue(buffer.scrollback.size() > 0)
@@ -631,7 +631,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should clear already empty buffer`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.clearAll()
 
@@ -644,7 +644,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should get character from screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABC")
 
@@ -656,7 +656,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should get character from scrollback`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJ")
 
@@ -666,7 +666,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should get attributes from screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("A")
 
@@ -680,7 +680,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should get line as string from screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABC")
 
@@ -690,7 +690,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should get line as string from scrollback`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJ")
 
@@ -699,7 +699,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should get entire screen content as string`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         buffer.writeText("ABCDEFG")
 
@@ -711,7 +711,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should get full content including scrollback and screen`() {
-        val buffer = TerminalBuffer(width = 5, height = 2, historySize = 10)
+        val buffer = TerminalBuffer(5, 2, 10)
 
         buffer.writeText("ABCDEFGHIJ")
 
@@ -723,7 +723,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should throw when screen row index is invalid`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         assertThrows(IllegalArgumentException::class.java) {
             buffer.getLineAsString(3)
@@ -732,7 +732,7 @@ class TerminalBufferTest {
 
     @Test
     fun `should throw when scrollback row index is invalid`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         assertThrows(IllegalArgumentException::class.java) {
             buffer.getLineAsString(0, fromHistory = true)
@@ -741,10 +741,102 @@ class TerminalBufferTest {
 
     @Test
     fun `should throw when column index is invalid`() {
-        val buffer = TerminalBuffer(width = 5, height = 3, historySize = 10)
+        val buffer = TerminalBuffer(5, 3, 10)
 
         assertThrows(IllegalArgumentException::class.java) {
             buffer.getCharAt(0, 5)
+        }
+    }
+
+    @Test
+    fun `should increase terminal buffer width and preserve content`() {
+        val buffer = TerminalBuffer(3, 2, 10)
+        buffer.writeText("ABC")
+
+        buffer.resize(5, 2)
+
+        assertEquals(5, buffer.width)
+        assertEquals(2, buffer.height)
+        assertEquals("ABC  ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+    }
+
+    @Test
+    fun `should decrease terminal buffer width and truncate screen and scrollback rows`() {
+        val buffer = TerminalBuffer(5, 2, 10)
+        buffer.writeText("ABCDEFGHIJ")
+
+        buffer.resize(3, 2)
+
+        assertEquals(3, buffer.width)
+        assertEquals(2, buffer.height)
+        assertEquals("ABC", buffer.scrollback[0].asString())
+        assertEquals("FGH", buffer[0].asString())
+        assertEquals("   ", buffer[1].asString())
+    }
+
+    @Test
+    fun `should increase terminal buffer height by appending empty rows`() {
+        val buffer = TerminalBuffer(5, 2, 10)
+        buffer.writeText("ABC")
+
+        buffer.resize(5, 4)
+
+        assertEquals(4, buffer.height)
+        assertEquals("ABC  ", buffer[0].asString())
+        assertEquals("     ", buffer[1].asString())
+        assertEquals("     ", buffer[2].asString())
+        assertEquals("     ", buffer[3].asString())
+    }
+
+    @Test
+    fun `should decrease terminal buffer height and move removed rows to scrollback`() {
+        val buffer = TerminalBuffer(5, 4, 10)
+        buffer.fillLine(0, 'A')
+        buffer.fillLine(1, 'B')
+        buffer.fillLine(2, 'C')
+        buffer.fillLine(3, 'D')
+
+        buffer.resize(5, 2)
+
+        assertEquals(2, buffer.height)
+        assertEquals("AAAAA", buffer.scrollback[0].asString())
+        assertEquals("BBBBB", buffer.scrollback[1].asString())
+        assertEquals("CCCCC", buffer[0].asString())
+        assertEquals("DDDDD", buffer[1].asString())
+    }
+
+    @Test
+    fun `should clamp cursor when resizing terminal buffer`() {
+        val buffer = TerminalBuffer(5, 4, 10)
+        buffer.setCursor(CursorPosition(3, 4))
+
+        buffer.resize(3, 2)
+
+        assertEquals(1, buffer.cursor.row)
+        assertEquals(2, buffer.cursor.column)
+    }
+
+    @Test
+    fun `should resize scrollback rows when resizing terminal buffer width`() {
+        val buffer = TerminalBuffer(5, 2, 10)
+        buffer.writeText("ABCDEFGHIJ")
+
+        buffer.resize(3, 2)
+
+        assertEquals("ABC", buffer.scrollback[0].asString())
+    }
+
+    @Test
+    fun `should throw when resizing terminal buffer to invalid size`() {
+        val buffer = TerminalBuffer(5, 2, 10)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.resize(0, 2)
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            buffer.resize(5, 0)
         }
     }
 }


### PR DESCRIPTION
## Description

Implements terminal resize support across the core buffer structures.

This change introduces resizing functionality for the terminal buffer by adding resize operations to `Row`, `Screen`, `Scrollback`, and `TerminalBuffer`. The implementation preserves as much existing content as possible while ensuring that screen and scrollback dimensions remain consistent.

Resize behavior is defined as a structural transformation rather than text reflow:
- increasing width appends empty cells to the right of rows
- decreasing width truncates cells on the right
- increasing height appends empty rows at the bottom
- decreasing height removes rows from the top and moves them to scrollback

The cursor position is clamped to valid bounds after resizing.

## Related Issue

Closes #29 

## Changes

- Implemented `Row.resize(newWidth)` to handle row width changes
- Implemented `Screen.resize(newWidth, newHeight)` to resize visible terminal grid
- Implemented `Scrollback.resize(newWidth)` to align history rows with new width
- Implemented `TerminalBuffer.resize(newWidth, newHeight)` to orchestrate full resize
- Added logic to move removed screen rows into scrollback when height decreases
- Added cursor clamping to ensure valid position after resize
- Added unit tests for row, screen, scrollback, and terminal buffer resize behavior

## Acceptance Criteria

- [x] Row width can be increased or decreased
- [x] Screen width and height can be resized
- [x] Screen rows removed due to height decrease are returned and stored in scrollback
- [x] Scrollback rows resize to match the new terminal width
- [x] Cursor position is clamped within new bounds
- [x] Existing content is preserved where possible
- [x] Code compiles successfully
- [x] Unit tests added and passing

## Tests

Added tests verifying:
- row width increase and decrease
- screen width and height resizing
- scrollback row resizing
- terminal buffer resize behavior
- movement of removed rows into scrollback
- cursor clamping after resize